### PR TITLE
Update genai-guide-part-1-6.html

### DIFF
--- a/_includes/genai-sections/genai-guide-part-1-6.html
+++ b/_includes/genai-sections/genai-guide-part-1-6.html
@@ -50,17 +50,17 @@
       <a
         target="_blank"
         rel="noreferrer noopener"
-        href="https://community.connect.gov/display/GSA/2023+Stanford+HAI+Training+Series"
+        href="https://coe.gsa.gov/communities/ai.html"
         tabindex="0">
         <p class="link-explanation">
-          AI Community of Practice (Connect.gov login required):
+          AI Community of Practice:
         </p>
         <p class="link-heading">
           <img
             class="link-icon"
             alt="Link icon"
             src="{{site.baseurl}}/assets/images/icons/link-icon.svg" />
-          2023 Stanford HAI Training Series
+          Learn about the governmentwide AI Community of Practice
           <img
             class="external-icon"
             alt="External icon"


### PR DESCRIPTION
Changed the AI Community of Practice link to https://coe.gsa.gov/communities/ai.html and updated descriptive text.